### PR TITLE
Added Asciinema Examples for all of Domain 1 Orchestration

### DIFF
--- a/Domain_1_Orchestration/Add_networks_publish_ports.md
+++ b/Domain_1_Orchestration/Add_networks_publish_ports.md
@@ -3,3 +3,6 @@
 ## Official Docker Documentation
 [Publish network ports in a Docker Swarm](https://docs.docker.com/engine/swarm/services/#publish-ports)  
 [Connect the service to an overlay network](https://docs.docker.com/engine/swarm/services/#connect-the-service-to-an-overlay-network)
+
+## Asciinema Examples
+[Add networks, publish ports](https://asciinema.org/a/SARGFvegQA7H1B6pNouiKSNPZ)

--- a/Domain_1_Orchestration/Apply_node_labels_to_demonstrate_placement_of_tasks.md
+++ b/Domain_1_Orchestration/Apply_node_labels_to_demonstrate_placement_of_tasks.md
@@ -6,3 +6,6 @@
 
 ## Preparation Hints
 There exists the possibilty to add custom labels on nearly every Docker Object: [Manage labels on objects](https://docs.docker.com/engine/userguide/labels-custom-metadata/#manage-labels-on-objects)
+
+## Asciinema Examples
+[Apply node labels to demonstrate placement of tasks](https://asciinema.org/a/fweACvdGhMzUFCEnFIXune226)

--- a/Domain_1_Orchestration/Complete_the_setup_of_a_swarm_mode_cluster_with_managers_and_worker_nodes.md
+++ b/Domain_1_Orchestration/Complete_the_setup_of_a_swarm_mode_cluster_with_managers_and_worker_nodes.md
@@ -3,3 +3,6 @@
 ## Official Docker Documentation
 [Create a Docker Swarm cluster](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/)  
 [Add nodes to the Docker Swarm cluster](https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/)
+
+## Asciinema Examples
+[Complete the setup of a swarm mode cluster with managers and worker nodes](https://asciinema.org/a/sxZFWFSL2B70Uzb6jyAmy9tKF)

--- a/Domain_1_Orchestration/Convert_an_application_deployment_into_a_stack_file_using_a_YAML_compose_file_with_docker_stack_deploy.md
+++ b/Domain_1_Orchestration/Convert_an_application_deployment_into_a_stack_file_using_a_YAML_compose_file_with_docker_stack_deploy.md
@@ -3,3 +3,6 @@
 ## Official Docker Documentation
 [Docker Stack Deploy](https://docs.docker.com/engine/reference/commandline/stack_deploy/)  
 [Docker Compose Service Configuration Reference](https://docs.docker.com/compose/compose-file/#service-configuration-reference)  
+
+## Asciinema Examples
+[Convert an application deployment into a stack file using a YAML compose file with docker stack deploy](https://asciinema.org/a/vtoxMgJiUMaay9IhNMporfpXV)

--- a/Domain_1_Orchestration/Demonstrate_steps_to_lock_a_swarm_cluster.md
+++ b/Domain_1_Orchestration/Demonstrate_steps_to_lock_a_swarm_cluster.md
@@ -2,3 +2,6 @@
 
 ## Official Docker Documentation
 [How to lock your Docker Swarm to protect its encryption key](https://docs.docker.com/engine/swarm/swarm_manager_locking/)  
+
+## Asciinema Examples
+[Demonstrate steps to lock a swarm cluster](https://asciinema.org/a/taLgo9ebq1Ut1KOjF1iyvXUEb)

--- a/Domain_1_Orchestration/Demonstrate_the_usage_of_templates_with_docker_service_create.md
+++ b/Domain_1_Orchestration/Demonstrate_the_usage_of_templates_with_docker_service_create.md
@@ -2,3 +2,6 @@
 
 ## Official Docker Documentation
 [Create Docker Swarm Services using templates](https://docs.docker.com/engine/reference/commandline/service_create/#create-services-using-templates)  
+
+## Asciinema Examples
+[Demonstrate the usage of templates with docker service create](https://asciinema.org/a/zZnpejurCS7bE7F5BQUobLHVo)

--- a/Domain_1_Orchestration/Identify_the_steps_needed_to_troubleshoot_a_service_not_deploying.md
+++ b/Domain_1_Orchestration/Identify_the_steps_needed_to_troubleshoot_a_service_not_deploying.md
@@ -5,3 +5,6 @@
 
 ## Third Party Resources
 [How to diagnose Service Problems](https://stackoverflow.com/a/41658522)
+
+## Asciinema Examples
+[Identify the steps needed to troubleshoot a service not deploying](https://asciinema.org/a/jwoYTaAYr4LEqhYBuRkEI9ets)

--- a/Domain_1_Orchestration/Illustrate_running_a_replicated_vs_global_service.md
+++ b/Domain_1_Orchestration/Illustrate_running_a_replicated_vs_global_service.md
@@ -2,3 +2,6 @@
 
 ## Official Docker Documentation
 [Replicated and Global Services](https://docs.docker.com/engine/swarm/how-swarm-mode-works/services/#replicated-and-global-services)  
+
+## Asciinema Examples
+[Illustrate running a replicated vs global service](https://asciinema.org/a/heYzOqTCEpJFNFZkwakkCv97z)

--- a/Domain_1_Orchestration/Increase_number_of_replicas.md
+++ b/Domain_1_Orchestration/Increase_number_of_replicas.md
@@ -4,3 +4,6 @@ Running Services on a Docker Swarm can be scaled in different ways: `docker serv
 
 ## Official Docker Documentation
 [Service Scale](https://docs.docker.com/engine/reference/commandline/service_scale/#examples)
+
+## Asciinema Examples
+[Increase number of replicas](https://asciinema.org/a/uwKaS8HHk35Aw4H8yCfD8XtG5)

--- a/Domain_1_Orchestration/Manipulate_a_running_stack_of_services.md
+++ b/Domain_1_Orchestration/Manipulate_a_running_stack_of_services.md
@@ -4,3 +4,6 @@ A running stack of services on Docker Swarm can be manipulated in different ways
 
 ## Official Docker Documentation
 [Commands to manipulate a running Stack of Services on Docker Swarm](https://docs.docker.com/engine/reference/commandline/stack_services/#related-commands)
+
+## Asciinema Examples
+[Manipulate a running stack of services](https://asciinema.org/a/4bqsdgv46EueyOPF48Fzd70dc)

--- a/Domain_1_Orchestration/Mount_volumes.md
+++ b/Domain_1_Orchestration/Mount_volumes.md
@@ -2,3 +2,6 @@
 
 ## Official Docker Documentation
 [How to give Docker Swarm Services access to Volumes or Bind Mounts](https://docs.docker.com/engine/swarm/services/#give-a-service-access-to-volumes-or-bind-mounts)  
+
+## Asciinema Examples
+[Mount volumes](https://asciinema.org/a/sExTsGhFBPW9LgLwzYN8afuOP)

--- a/Domain_1_Orchestration/State_the_differences_between_running_a_container_vs_running_a_service.md
+++ b/Domain_1_Orchestration/State_the_differences_between_running_a_container_vs_running_a_service.md
@@ -6,3 +6,6 @@
 
 ## Third Party Resources
 [What is the difference between Docker Service and Docker Container?](https://stackoverflow.com/a/43408904)
+
+## Asciinema Examples
+[State the differences between running a container vs running a service](https://asciinema.org/a/TlMJZDNKZCeUYSfRbmyiKXK46)


### PR DESCRIPTION
Please look over my examples
I have went over the documentation and made what I feel to be quality Asciinema examples for each of the objectives in Domain 1. 

This merge would not update the main page, I did not include that update in the README.md 

There was also a few objectives I could not cover in Asciinema as it didn't make sense on a terminal.

**Extend the instructions to run individual containers into running services under swarm**
(essentially the same thing as previous examples on deploying services) 

**Interpret the output of docker inspect commands**
**Sketch how a Dockerized application communicates with legacy systems**
**Paraphrase the importance of quorum in a swarm cluster**

